### PR TITLE
Add cart with item limit

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CartItem;
+use App\Models\Order;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class CartController extends Controller
+{
+    public function index()
+    {
+        $items = CartItem::with('product')->where('user_id', Auth::id())->get();
+        return response()->json($items);
+    }
+
+    public function add(Request $request)
+    {
+        $request->validate([
+            'product_id' => 'required|exists:products,id',
+            'quantity' => 'required|integer|min:1',
+        ]);
+
+        $currentTotal = CartItem::where('user_id', Auth::id())->sum('quantity');
+        if ($currentTotal + $request->quantity > 5) {
+            return response()->json(['error' => 'You can not order more than 5 items'], 422);
+        }
+
+        $item = CartItem::firstOrNew([
+            'user_id' => Auth::id(),
+            'product_id' => $request->product_id,
+        ]);
+        $newQty = $item->exists ? $item->quantity + $request->quantity : $request->quantity;
+        if ($newQty > 5) {
+            return response()->json(['error' => 'You can not order more than 5 items'], 422);
+        }
+        $item->quantity = $newQty;
+        $item->save();
+
+        return response()->json($item, 201);
+    }
+
+    public function remove(CartItem $item)
+    {
+        if ($item->user_id !== Auth::id()) {
+            return response()->json(['error' => 'Not authorized'], 403);
+        }
+        $item->delete();
+        return response()->json(['message' => 'Item removed']);
+    }
+
+    public function checkout()
+    {
+        $items = CartItem::where('user_id', Auth::id())->get();
+        if ($items->isEmpty()) {
+            return response()->json(['error' => 'Cart is empty'], 422);
+        }
+
+        $orders = [];
+        foreach ($items as $item) {
+            $orders[] = Order::create([
+                'user_id' => Auth::id(),
+                'product_id' => $item->product_id,
+                'order_number' => Str::upper(Str::random(8)),
+                'amount' => $item->product->price * $item->quantity,
+                'status' => 'new',
+                'quantity' => $item->quantity,
+            ]);
+            $item->delete();
+        }
+
+        return response()->json($orders, 201);
+    }
+}

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -166,6 +166,7 @@ class OrderController extends Controller
             'order_number' => 'required|string|unique:orders,order_number',
             'amount' => 'required|numeric',
             'status' => 'required|in:new,processing,shipped,delivered',
+            'quantity' => 'required|integer|min:1|max:5',
         ]);
 
         $order = Order::create([
@@ -174,6 +175,7 @@ class OrderController extends Controller
             'order_number' => $request->order_number,
             'amount' => $request->amount,
             'status' => $request->status,
+            'quantity' => $request->quantity,
         ]);
 
         // Відправка сповіщення про створення замовлення
@@ -234,9 +236,10 @@ class OrderController extends Controller
             'product_id' => 'integer|exists:products,id',
             'amount' => 'numeric',
             'status' => 'in:new,processing,shipped,delivered',
+            'quantity' => 'integer|min:1|max:5',
         ]);
 
-        $order->update($request->only(['product_id', 'amount', 'status']));
+        $order->update($request->only(['product_id', 'amount', 'status', 'quantity']));
 
         // Відправка сповіщення про зміну статусу, якщо він змінений
         if ($request->status && $request->status !== $oldStatus) {

--- a/app/Models/CartItem.php
+++ b/app/Models/CartItem.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CartItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'product_id',
+        'quantity',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -17,6 +17,7 @@ class Order extends Model
         'order_number',
         'amount',
         'status',
+        'quantity',
     ];
 
     // Статуси замовлення

--- a/database/factories/CartItemFactory.php
+++ b/database/factories/CartItemFactory.php
@@ -2,26 +2,23 @@
 
 namespace Database\Factories;
 
-use App\Models\Order;
+use App\Models\CartItem;
 use App\Models\User;
 use App\Models\Product;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends Factory<Order>
+ * @extends Factory<CartItem>
  */
-class OrderFactory extends Factory
+class CartItemFactory extends Factory
 {
-    protected $model = Order::class;
+    protected $model = CartItem::class;
 
     public function definition(): array
     {
         return [
             'user_id' => User::factory(),
             'product_id' => Product::factory(),
-            'order_number' => $this->faker->unique()->bothify('ORD###'),
-            'amount' => $this->faker->randomFloat(2, 10, 500),
-            'status' => 'new',
             'quantity' => $this->faker->numberBetween(1, 5),
         ];
     }

--- a/database/migrations/2026_06_27_000001_create_cart_items_table.php
+++ b/database/migrations/2026_06_27_000001_create_cart_items_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cart_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('product_id')->constrained()->onDelete('cascade');
+            $table->integer('quantity');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cart_items');
+    }
+};

--- a/database/migrations/2026_06_27_000002_add_quantity_to_orders_table.php
+++ b/database/migrations/2026_06_27_000002_add_quantity_to_orders_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->integer('quantity')->default(1);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn('quantity');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\OrderController;
 use App\Http\Controllers\ProductController;
+use App\Http\Controllers\CartController;
 
 Route::post('register', [AuthController::class, 'register']);
 Route::post('login', [AuthController::class, 'login']);
@@ -17,6 +18,10 @@ Route::middleware('auth:api')->group(function () {
     Route::get('/orders/export-excel', [OrderController::class, 'exportExcel']);
     Route::get('/orders/export-csv', [OrderController::class, 'exportCsv']);
     Route::get('/orders/export-pdf', [OrderController::class, 'exportPdf']);
+    Route::get('cart', [CartController::class, 'index']);
+    Route::post('cart/add', [CartController::class, 'add']);
+    Route::delete('cart/{item}', [CartController::class, 'remove']);
+    Route::post('cart/checkout', [CartController::class, 'checkout']);
     Route::get('products', [ProductController::class, 'index']);
     Route::post('products', [ProductController::class, 'store']);
     Route::get('products/{product}', [ProductController::class, 'show']);

--- a/tests/Feature/CartControllerTest.php
+++ b/tests/Feature/CartControllerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\CartItem;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CartControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $user;
+    protected $product;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->product = Product::factory()->create();
+    }
+
+    /** @test */
+    public function user_can_add_item_to_cart_and_checkout()
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->postJson('/api/cart/add', [
+            'product_id' => $this->product->id,
+            'quantity' => 3,
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('cart_items', ['user_id' => $this->user->id]);
+
+        $checkout = $this->postJson('/api/cart/checkout');
+        $checkout->assertStatus(201);
+        $this->assertDatabaseHas('orders', ['user_id' => $this->user->id, 'quantity' => 3]);
+        $this->assertDatabaseCount('cart_items', 0);
+    }
+
+    /** @test */
+    public function user_cannot_add_more_than_five_items()
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->postJson('/api/cart/add', [
+            'product_id' => $this->product->id,
+            'quantity' => 6,
+        ]);
+
+        $response->assertStatus(422);
+    }
+}

--- a/tests/Feature/OrderControllerTest.php
+++ b/tests/Feature/OrderControllerTest.php
@@ -52,6 +52,7 @@ class OrderControllerTest extends TestCase
             'order_number' => 'ORD123',
             'amount' => 100,
             'status' => 'new',
+            'quantity' => 2,
         ];
 
         $response = $this->postJson('/api/orders', $orderData);
@@ -85,6 +86,7 @@ class OrderControllerTest extends TestCase
             'product_id' => $this->product->id,
             'amount' => 150,
             'status' => 'shipped',
+            'quantity' => 3,
         ];
 
         $response = $this->putJson("/api/orders/{$order->id}", $updatedData);


### PR DESCRIPTION
## Summary
- add CartController and CartItem model
- support adding items to a cart and checking out to orders
- limit total quantity per order to five
- add quantity field for orders
- cover cart behaviour with feature tests

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3d37e458832082f052796dd858be