### PR TITLE
Add analytics summary endpoint

### DIFF
--- a/app/Http/Controllers/AnalyticsController.php
+++ b/app/Http/Controllers/AnalyticsController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Order;
+use Illuminate\Http\Request;
+
+class AnalyticsController extends Controller
+{
+    public function summary(Request $request)
+    {
+        $ordersQuery = Order::query();
+
+        if ($request->filled('from')) {
+            $ordersQuery->whereDate('orders.created_at', '>=', $request->input('from'));
+        }
+
+        if ($request->filled('to')) {
+            $ordersQuery->whereDate('orders.created_at', '<=', $request->input('to'));
+        }
+
+        $productSales = (clone $ordersQuery)
+            ->select('products.id as product_id', 'products.name')
+            ->selectRaw('SUM(orders.quantity) as total_quantity')
+            ->selectRaw('SUM(orders.amount) as total_amount')
+            ->join('products', 'orders.product_id', '=', 'products.id')
+            ->groupBy('products.id', 'products.name')
+            ->get();
+
+        $userOrders = (clone $ordersQuery)
+            ->select('users.id as user_id', 'users.name')
+            ->selectRaw('COUNT(*) as total_orders')
+            ->selectRaw('SUM(orders.amount) as total_amount')
+            ->join('users', 'orders.user_id', '=', 'users.id')
+            ->groupBy('users.id', 'users.name')
+            ->get();
+
+        return response()->json([
+            'product_sales' => $productSales,
+            'user_orders' => $userOrders,
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,4 +27,7 @@ Route::middleware('auth:api')->group(function () {
     Route::get('products/{product}', [ProductController::class, 'show']);
     Route::put('products/{product}', [ProductController::class, 'update']);
     Route::delete('products/{product}', [ProductController::class, 'destroy']);
+
+    // Analytics
+    Route::get('analytics', [\App\Http\Controllers\AnalyticsController::class, 'summary']);
 });

--- a/tests/Feature/AnalyticsControllerTest.php
+++ b/tests/Feature/AnalyticsControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AnalyticsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function authenticated_user_can_view_sales_summary()
+    {
+        $user = User::factory()->create();
+        $anotherUser = User::factory()->create();
+        $product = Product::factory()->create(['price' => 10]);
+        $product2 = Product::factory()->create(['price' => 20]);
+
+        Order::factory()->create([
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+            'amount' => 30,
+            'quantity' => 3,
+        ]);
+        Order::factory()->create([
+            'user_id' => $anotherUser->id,
+            'product_id' => $product2->id,
+            'amount' => 40,
+            'quantity' => 2,
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->getJson('/api/analytics');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'product_sales' => [['product_id', 'name', 'total_quantity', 'total_amount']],
+            'user_orders' => [['user_id', 'name', 'total_orders', 'total_amount']],
+        ]);
+    }
+
+    /** @test */
+    public function sales_summary_can_be_filtered_by_date_range()
+    {
+        $user = User::factory()->create();
+        $product = Product::factory()->create(['price' => 10]);
+
+        Order::factory()->create([
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+            'amount' => 20,
+            'quantity' => 2,
+            'created_at' => now()->subDays(2),
+        ]);
+
+        Order::factory()->create([
+            'user_id' => $user->id,
+            'product_id' => $product->id,
+            'amount' => 50,
+            'quantity' => 5,
+            'created_at' => now()->subDays(10),
+        ]);
+
+        $this->actingAs($user);
+
+        $from = now()->subDays(3)->toDateString();
+        $to = now()->toDateString();
+
+        $response = $this->getJson("/api/analytics?from={$from}&to={$to}");
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'total_quantity' => 2,
+            'total_amount' => 20,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AnalyticsController` for sales data
- expose `/api/analytics` route
- cover analytics with feature test
- support date range filtering for analytics

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68629cded0dc8320a2147dc27b0d8de9