### PR TITLE
Separate sales and order analytics

### DIFF
--- a/app/Http/Controllers/AnalyticsController.php
+++ b/app/Http/Controllers/AnalyticsController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 
 class AnalyticsController extends Controller
 {
-    public function summary(Request $request)
+    private function buildOrdersQuery(Request $request)
     {
         $ordersQuery = Order::query();
 
@@ -18,6 +18,43 @@ class AnalyticsController extends Controller
         if ($request->filled('to')) {
             $ordersQuery->whereDate('orders.created_at', '<=', $request->input('to'));
         }
+
+        return $ordersQuery;
+    }
+
+    public function sales(Request $request)
+    {
+        $ordersQuery = $this->buildOrdersQuery($request);
+
+        $productSales = $ordersQuery
+            ->select('products.id as product_id', 'products.name')
+            ->selectRaw('SUM(orders.quantity) as total_quantity')
+            ->selectRaw('SUM(orders.amount) as total_amount')
+            ->join('products', 'orders.product_id', '=', 'products.id')
+            ->groupBy('products.id', 'products.name')
+            ->get();
+
+        return response()->json(['product_sales' => $productSales]);
+    }
+
+    public function orders(Request $request)
+    {
+        $ordersQuery = $this->buildOrdersQuery($request);
+
+        $userOrders = $ordersQuery
+            ->select('users.id as user_id', 'users.name')
+            ->selectRaw('COUNT(*) as total_orders')
+            ->selectRaw('SUM(orders.amount) as total_amount')
+            ->join('users', 'orders.user_id', '=', 'users.id')
+            ->groupBy('users.id', 'users.name')
+            ->get();
+
+        return response()->json(['user_orders' => $userOrders]);
+    }
+
+    public function summary(Request $request)
+    {
+        $ordersQuery = $this->buildOrdersQuery($request);
 
         $productSales = (clone $ordersQuery)
             ->select('products.id as product_id', 'products.name')

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,4 +30,6 @@ Route::middleware('auth:api')->group(function () {
 
     // Analytics
     Route::get('analytics', [\App\Http\Controllers\AnalyticsController::class, 'summary']);
+    Route::get('analytics/sales', [\App\Http\Controllers\AnalyticsController::class, 'sales']);
+    Route::get('analytics/orders', [\App\Http\Controllers\AnalyticsController::class, 'orders']);
 });

--- a/tests/Feature/AnalyticsControllerTest.php
+++ b/tests/Feature/AnalyticsControllerTest.php
@@ -35,11 +35,17 @@ class AnalyticsControllerTest extends TestCase
 
         $this->actingAs($user);
 
-        $response = $this->getJson('/api/analytics');
+        $response = $this->getJson('/api/analytics/sales');
 
         $response->assertStatus(200);
         $response->assertJsonStructure([
             'product_sales' => [['product_id', 'name', 'total_quantity', 'total_amount']],
+        ]);
+
+        $response = $this->getJson('/api/analytics/orders');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
             'user_orders' => [['user_id', 'name', 'total_orders', 'total_amount']],
         ]);
     }
@@ -71,7 +77,7 @@ class AnalyticsControllerTest extends TestCase
         $from = now()->subDays(3)->toDateString();
         $to = now()->toDateString();
 
-        $response = $this->getJson("/api/analytics?from={$from}&to={$to}");
+        $response = $this->getJson("/api/analytics/sales?from={$from}&to={$to}");
 
         $response->assertStatus(200);
         $response->assertJsonFragment([


### PR DESCRIPTION
## Summary
- split analytics endpoints
- add routes for sales and orders analytics
- update tests to check new endpoints

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68629ec8d7a88320a5767d676d713e75