### PR TITLE
Add AuthController unit tests

### DIFF
--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AuthControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function user_can_register()
+    {
+        $data = [
+            'name' => 'New User',
+            'email' => 'new@example.com',
+            'password' => 'secret123',
+            'password_confirmation' => 'secret123',
+        ];
+
+        $response = $this->postJson('/api/register', $data);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure(['user' => ['id', 'name', 'email'], 'token']);
+        $this->assertDatabaseHas('users', ['email' => 'new@example.com']);
+    }
+
+    /** @test */
+    public function user_can_login_with_correct_credentials()
+    {
+        $user = User::factory()->create(['password' => Hash::make('password')]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['token']);
+    }
+
+    /** @test */
+    public function user_cannot_login_with_invalid_credentials()
+    {
+        $user = User::factory()->create(['password' => Hash::make('password')]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => $user->email,
+            'password' => 'wrong',
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    /** @test */
+    public function authenticated_user_can_logout()
+    {
+        $user = User::factory()->create(['password' => Hash::make('password')]);
+
+        $login = $this->postJson('/api/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ]);
+
+        $token = $login->json('token');
+
+        $response = $this->withHeader('Authorization', "Bearer {$token}")
+                         ->postJson('/api/logout');
+
+        $response->assertStatus(200);
+        $response->assertExactJson(['message' => 'Successfully logged out']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a test suite for AuthController covering register, login and logout flows

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68836858e61883208b0772b30c48d8b5